### PR TITLE
Add link to JabRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ a paper.  One solution to this issue is to embed the respective `.bib`
 file exist in `bibtexdir`, it gets embedded in the PDF.
 
 You can use the
-[bibutils](https://sourceforge.net/p/bibutils/home/bib2xml/) for
-converting between these different formats for bibliographic
+[bibutils](https://sourceforge.net/p/bibutils/home/bib2xml/) or
+[JabRef](https://www.jabref.org)
+for converting between these different formats for bibliographic
 references easily. 
 
 


### PR DESCRIPTION
I could not resist to put "JabRef" as alternative to bibutils. These two tools target different users. More GUI users will tend to use JabRef, whereas "console lovers" will use bibutils (or try to understand https://help.jabref.org/en/CommandLine and use JabRef's command line capabilities).

EDIT: I saw that there used to be a reference to JabRef and it got removed at https://github.com/adbrucker/authorarchive/commit/2084bdb3ee8624eb51a91aad8ad849073cdef158. Maybe, offering a link to two tools covers more potential users?