### PR TITLE
Patch 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- The links to the embedded files (references) are typeset at the bottom of the paper.
+
 ### Changed
 - Updated LNCS output to the requirements of [Springer's Consent to Publish v3](http://resource-cms.springer.com/springer-cms/rest/v1/content/731196/data/v3).
 - If `nourl` is active, the DOI is used as link for the QR code.
 - Text is centered if no QR code (`nourl` + no DOI) is generated.
+- File embedding is implemented using the [attachfilfe](https://ctan.org/pkg/attachfile) package.
 - ACM format adapted to [acmart](https://github.com/borisveytsman/acmart) v1.50.
 
 ## [1.0.0] - 2018-02-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Updated LNCS output to the requirements of [Springer's Consent to Publish v3](http://resource-cms.springer.com/springer-cms/rest/v1/content/731196/data/v3).
+- If `nourl` is active, the DOI is used as link for the QR code.
+- Text is centered if no QR code (`nourl` + no DOI) is generated.
 
 ## [1.0.0] - 2018-02-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Updated LNCS output to the requirements of [Springer's Consent to Publish v3](http://resource-cms.springer.com/springer-cms/rest/v1/content/731196/data/v3).
+
 ## [1.0.0] - 2018-02-21
 ### Added
 - Initial version uploaded to CTAN.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated LNCS output to the requirements of [Springer's Consent to Publish v3](http://resource-cms.springer.com/springer-cms/rest/v1/content/731196/data/v3).
 - If `nourl` is active, the DOI is used as link for the QR code.
 - Text is centered if no QR code (`nourl` + no DOI) is generated.
+- ACM format adapted to [acmart](https://github.com/borisveytsman/acmart) v1.50.
 
 ## [1.0.0] - 2018-02-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   * [Key/Value Options](#keyvalue-options)
 - [Embedding Bibliography Entries](#embedding-bibliography-entries)
 - [Development](#development)
+- [Notes on Self-Archiving](#notes-on-self-archiving)
 - [Alternative Packages](#alternative-packages)
 - [License](#license)
 
@@ -91,6 +92,36 @@ You can use the
 [bibutils](https://sourceforge.net/p/bibutils/home/bib2xml/) for
 converting between these different formats for bibliographic
 references easily. 
+
+## Notes on Self-Archiving
+
+Before using this package, please check with your signed copyright form,
+which rights you have. None of the authors might be hold liable for copyright
+violations by using this package.
+
+### LNCS
+Sprinter states in his [Springer's Consent to Publish v3](http://resource-cms.springer.com/springer-cms/rest/v1/content/731196/data/v3):
+
+> Author may only post his/her own version, provided acknowledgment is given to the original source of publication and a link is inserted to the published article on Springer’s website.
+> The link must be provided by inserting the DOI number of the article in the following sentence:
+> "The final publication is available at Springer via `http://dx.doi.org/[insert DOI]`".
+The DOI (Digital Object Identifier) can be found at the bottom of the first page of the published paper.
+
+This package uses `https://doi.org` as `http://dx.doi.org` [is deprecated](https://www.doi.org/factsheets/DOIIdentifierSpecs.html).
+
+Thus, the proposed configuration for Springer is as follows:
+
+```latex
+\usepackage[LNCS,
+   key=brucker-authorarchive-2016,
+   year=2016,
+   publication={Anonymous et al. (eds). Proceedings of the International
+       Conference on LaTeX-Hacks, LNCS~42. Springer, 2016.}
+   startpage={42},
+   doi={10.1038/authorarchive},
+   nocopyright
+ ]{authorarchive}
+```
 
 
 ## Alternative Packages

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ A simple use for LNCS-formatted papers is as follows:
 
 The following layout-styles are pre-defined:
 * `ACM` for the two-column layout used by many ACM conferences
+* `ENTCS` for the Elsevier ENTCS layout
 * `IEEE` for the two-column layout used by many IEEE conferences 
 * `LNCS` for the LNCS layout (as used by Springer)
 * `LNI` for the Lecture Notes in Informatics, published by the GI
-* `ENTCS` for the Elsevier ENTCS layout
 
 By re-defining the font command (`authorcrfont{}`) and the command that is
 used for positioning the copyright text (`\authorat{}`), the package can 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ bottom of the first page of the paper and required links to the
 publisher are generated.
 
 The package
-[llncsconf](https://git.logicalhacking.com/adbrucker/llncsconf) is a
+[llncsconf](https://ctan.org/pkg/llncsconf) is a
 light-weight alternative to this package.  It supports
 [LNCS](http://www.springer.com/de/it-informatik/lncs) only.  In
 comparison to `authorarchive`, it provides support for the additional

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ a paper.  One solution to this issue is to embed the respective `.bib`
 file exist in `bibtexdir`, it gets embedded in the PDF.
 
 You can use the
-[bibutils](https://sourceforge.net/p/bibutils/home/bib2xml/) for
+[bibutils](https://sourceforge.net/p/bibutils/home/Bibutils/) for
 converting between these different formats for bibliographic
 references easily. 
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,22 @@ Thus, the proposed configuration for Springer is as follows:
  ]{authorarchive}
 ```
 
+## Other publishers
+One does not need to specify a certain publisher. The default setting just
+prints the note centered at the bottom of the first page.
+
+```latex
+\usepackage[
+   key=brucker-authorarchive-2017,
+   year=2017,
+   publication={Anonymous et al. (eds). Proceedings of the International
+       Conference on LaTeX-Hacks, CEUR-WS Vol~42, 2017.}
+   startpage={42},
+   doi={10.1039/authorarchive},
+   nocopyright
+ ]{authorarchive}
+```
+
 
 ## Alternative Packages
 The package [coverpage](https://ctan.org/pkg/coverpage) prepends a

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -41,13 +41,13 @@
 \DeclareStringOption[UNKNOWN PUBLICATION]{publication}[]
 
 \DeclareBoolOption{ACM}
+\DeclareBoolOption{ENTCS}
 \DeclareBoolOption{IEEE}
 \DeclareBoolOption{LNCS}
 \DeclareBoolOption{LNI}
 \DeclareBoolOption{nocopyright}
 \DeclareBoolOption{nourl}
 \DeclareBoolOption{nobib}
-\DeclareBoolOption{ENTCS}
 %\ProcessOptions\relax
 
 

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -201,7 +201,13 @@
 \AddToShipoutPicture*{%
   \setlength{\unitlength}{1mm}%
   \authorat{%
-    \ifAA@nourl\relax\else%
+    \ifAA@nourl%
+       \ifx\AA@doi\@empty%
+         \hspace{0.585cm}
+       \else%
+          \raisebox{.5cm}[.5cm]{\qrcode[hyperlink,height=1.17cm,padding]{https://doi.org/\AA@doi}}%
+        \fi%
+    \else%
       \raisebox{.5cm}[.5cm]{\qrcode[hyperlink,height=1.17cm,padding]{\AA@baseurl/\AA@key\AA@suffix}}%
     \fi%
     \authorcrfont\parbox[b]{\AA@width-1.4cm}{

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -222,10 +222,9 @@
         \ifx\AA@doi\@empty%
           \relax
         \else
-          The definitive
-          version was published with doi:
+          The final publication is available at Springer via
           \ifx\AA@doiText\@empty%
-            \href{https://doi.org/\AA@doi}{\AA@doi}.
+            \url{https://doi.org/\AA@doi}.
           \else
             \href{https://doi.org/\AA@doi}{\AA@doiText}.
           \fi

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -7,6 +7,8 @@
 %%   version 1 of the License, or any later version.
 %%   OR
 %%   The 2-clause BSD-style license.
+%%
+%%   SPDX-License-Identifier: LPPL-1.0+ OR BSD-2-Clause
 \NeedsTeXFormat{LaTeX2e}\relax
 \ProvidesPackage{authorarchive}
   [0000/00/00 Unreleased v1.0.0+%

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -91,13 +91,8 @@
 
 \ifAA@ACM%
   \setkeys{AA}{publisher=ACM}
-  \global\boilerplate={}
-  \global\copyrightetc={}
-  \renewcommand{\conferenceinfo}[2]{}
-  \renewcommand{\authorcrfont}{\crnotice}
-  \setlength\AA@y{-\textheight+\topmargin+\headheight} % -\voffset-\topmargin-\headheight-\footskip}
-  \renewcommand{\authorat}[1]{\put(\LenToUnit{\AA@x},\LenToUnit{\AA@y}){#1}}
-  \setlength{\AA@width}{\columnwidth}
+  \renewcommand{\authorat}[1]{\AtPageUpperLeft{\put(\LenToUnit{\AA@x},\LenToUnit{-\paperheight}){#1}}}
+  \setlength{\AA@width}{\textwidth}
 \fi
 %%%% LNCS
 \ifAA@LNCS%

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -13,13 +13,16 @@
   Self-archiving information for scientific publications.]
 %
 \RequirePackage{ifthen}
+\RequirePackage[inline]{enumitem}
 \RequirePackage{graphicx}
-\RequirePackage{hyperref}
 \RequirePackage{eso-pic}
-\RequirePackage{embedfile}
+\RequirePackage{attachfile}
 \RequirePackage{kvoptions}
+\RequirePackage{hyperref}
+\RequirePackage{hypgotoe}
 \RequirePackage{calc}
 \RequirePackage{qrcode}
+\RequirePackage{dtk-logos}
 %
 % Option declarations
 % -------------------
@@ -152,42 +155,6 @@
   pdftitle      = {\@title},
 }
 
-\ifAA@nobib\relax\else%
-  \AtBeginDocument{%
-    \IfFileExists{\AA@bibtexdir/\AA@key.bib}{%
-      \embedfile[filespec=\AA@key.bib,%
-        desc={BibTeX entry of this paper.},%
-        stringmethod=escape,%
-        mimetype=plain/text,%
-      ]{\AA@bibtexdir/\AA@key.bib}}{
-      \typeout{No file \AA@bibtexdir/\AA@key.bib found. Not embedded reference in BibTeX format.}
-    }%
-    \IfFileExists{\AA@bibtexdir/\AA@key.enw}{%
-      \embedfile[filespec=\AA@key.enw,%
-        desc={Endnote entry of this paper.},%
-        stringmethod=escape,%
-        mimetype=plain/text,%
-      ]{\AA@bibtexdir/\AA@key.enw}}{
-      \typeout{No file \AA@bibtexdir/\AA@key.enw found. Not embedded reference in Endnote format.}
-    }%
-    \IfFileExists{\AA@bibtexdir/\AA@key.ris}{%
-      \embedfile[filespec=\AA@key.ris,%
-        desc={RIS entry of this paper.},%
-        stringmethod=escape,%
-        mimetype=plain/text,%
-      ]{\AA@bibtexdir/\AA@key.ris}}{
-      \typeout{No file \AA@bibtexdir/\AA@key.ris found. Not embedded reference in RIS format.}
-    }%
-    \IfFileExists{\AA@bibtexdir/\AA@key.word.xml}{%
-      \embedfile[filespec=\AA@key.word.xml,%
-        desc={XML entry of this paper (e.g., for Word 2007 and later).},%
-        stringmethod=escape,%
-        mimetype=plain/text,%
-      ]{\AA@bibtexdir/\AA@key.word.xml}}{
-      \typeout{No file \AA@bibtexdir/\AA@key.word.xml found. Not embedded reference for Word 2007 and later.}
-    }%
-  }%
-\fi
 \AtEndDocument{\label{LastPage}}
 
 \AddToShipoutPicture*{%
@@ -254,6 +221,64 @@
             , doi: \href{https://doi.org/\AA@doi}{\AA@doiText}.%
           \fi
         \fi
+      \fi
+      \ifAA@nobib\relax\else%
+        \hfill
+        % We need "doubleprint", because the text of \textattachfile is not printed when printing a PDF
+        % We use the idea from https://tex.stackexchange.com/a/19045/9075, accepting that
+        % the pointers to the files are renderedin semi-bold way
+        \newlength{\Urlname}
+        \newcommand{\doubleprint}[1]{\setlength{\Urlname}{\widthof{#1}}\hspace{-\Urlname}#1}
+        \begin{itemize*}[label={}, itemjoin={,}]
+          \IfFileExists{\AA@bibtexdir/\AA@key.bib}{%
+            \item \textattachfile[%
+                print=true,%
+                color=0 0 0,%
+                icon=Paperclip,%
+                description={BibTeX entry of this paper},%
+                mimetype=application/x-bibtex%
+              ]{\AA@bibtexdir/\AA@key.bib}{\BibTeX}%
+              \doubleprint{\BibTeX}
+          }{
+            \typeout{No file \AA@bibtexdir/\AA@key.bib found. Not embedded reference in BibTeX format.}
+          }
+          \IfFileExists{\AA@bibtexdir/\AA@key.word.xml}{%
+            \item \textattachfile[%
+                print=true,%
+                color=0 0 0,%
+                icon=Paperclip,%
+                description={XML entry of this paper (e.g., for Word 2007 and later)},%
+                mimetype=application/xml%
+              ]{\AA@bibtexdir/\AA@key.word.xml}{Word}%
+              \doubleprint{Word}
+          }{
+            \typeout{No file \AA@bibtexdir/\AA@key.word.xml found. Not embedded reference for Word 2007 and later.}
+          }
+          \IfFileExists{\AA@bibtexdir/\AA@key.enw}{%
+            \item \textattachfile[%
+                print=true,%
+                color=0 0 0,%
+                icon=Paperclip,%
+                description={Endnote entry of this paper},%
+                mimetype=application/x-endnote-refer%
+              ]{\AA@bibtexdir/\AA@key.enw}{EndNote}%
+              \doubleprint{EndNote}
+          }{
+            \typeout{No file \AA@bibtexdir/\AA@key.enw found. Not embedded reference in Endnote format.}
+          }
+          \IfFileExists{\AA@bibtexdir/\AA@key.ris}{%
+            \item \textattachfile[%
+                print=true,%
+                color=0 0 0,%
+                icon=Paperclip,%
+                description={RIS entry of this paper},%
+                mimetype=application/x-research-info-systems%
+              ]{\AA@bibtexdir/\AA@key.ris}{RIS}%
+              \doubleprint{RIS}
+          }{
+            \typeout{No file \AA@bibtexdir/\AA@key.ris found. Not embedded reference in RIS format.}
+          }
+        \end{itemize*}
       \fi
     }
   }

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -14,6 +14,8 @@
   [0000/00/00 Unreleased v1.0.0+%
   Self-archiving information for scientific publications.]
 %
+\PassOptionsToPackage{hyphens}{url}
+%
 \RequirePackage{ifthen}
 \RequirePackage[inline]{enumitem}
 \RequirePackage{graphicx}
@@ -26,13 +28,16 @@
 \RequirePackage{qrcode}
 \RequirePackage{dtk-logos}
 %
+%Better url breaking
+\g@addto@macro{\UrlBreaks}{\UrlOrds}
+%
 % Option declarations
 % -------------------
 \SetupKeyvalOptions{
   family=AA,
   prefix=AA@
 }
-
+%
 \DeclareStringOption[.]{bibtexdir}
 \DeclareStringOption[https://duckduckgo.com/?q=]{baseurl}
 \DeclareStringOption[.pdf]{suffix}

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -80,8 +80,10 @@
 \newlength\AA@y
 \newlength\AA@width
 
+\setlength\AA@x{1in+\hoffset+\oddsidemargin}
+
 \newcommand{\authorcrfont}{\footnotesize}
-\newcommand{\authorat}[1]{\put(100,100){#1}}
+\newcommand{\authorat}[1]{\AtPageUpperLeft{\put(\LenToUnit{\AA@x},\LenToUnit{-\paperheight}){#1}}}
 \newcommand{\authorwidth}[1]{\setlength{\AA@width}{#1}}
 \setlength{\AA@width}{\textwidth}
 
@@ -93,7 +95,6 @@
   \global\copyrightetc={}
   \renewcommand{\conferenceinfo}[2]{}
   \renewcommand{\authorcrfont}{\crnotice}
-  \setlength\AA@x{1in+\hoffset+\oddsidemargin}
   \setlength\AA@y{-\textheight+\topmargin+\headheight} % -\voffset-\topmargin-\headheight-\footskip}
   \renewcommand{\authorat}[1]{\put(\LenToUnit{\AA@x},\LenToUnit{\AA@y}){#1}}
   \setlength{\AA@width}{\columnwidth}
@@ -101,7 +102,6 @@
 %%%% LNCS
 \ifAA@LNCS%
   \setkeys{AA}{publisher=Springer-Verlag}
-  \setlength\AA@x{1in+\hoffset+\oddsidemargin}
   \renewcommand{\authorat}[1]{\put(\LenToUnit{\AA@x},27){#1}}
   \renewcommand{\authorcrfont}{\scriptsize}
   \pdfpagesattr{/CropBox [92 65 523 731]}% LNCS page: 152x235 mm
@@ -112,7 +112,6 @@
 %%%% LNI
 \ifAA@LNI%
   \setkeys{AA}{publisher=GI}
-  \setlength\AA@x{1in+\hoffset+\oddsidemargin}
   \renewcommand{\authorat}[1]{\put(\LenToUnit{\AA@x},35){#1}}
   \renewcommand{\authorcrfont}{\scriptsize}
   \pdfpagesattr{/CropBox [70 65 526.378 748.15]} % TODO
@@ -124,7 +123,6 @@
 \ifAA@ENTCS%
   \addtolength{\voffset}{1cm}
   \setkeys{AA}{publisher=Elsevier Science B.~V.}
-  \setlength\AA@x{1in+\hoffset+\oddsidemargin}
   \renewcommand{\authorat}[1]{\put(\LenToUnit{\AA@x},-250){#1}}
   \renewcommand{\authorcrfont}{\scriptsize}
   \def\@oddfoot{}
@@ -144,7 +142,6 @@
 %%%% IEEE
 \ifAA@IEEE%
   \setkeys{AA}{publisher=IEEE Computer Society}
-  \setlength\AA@x{1in+\hoffset+\oddsidemargin}
   \renewcommand{\authorat}[1]{\put(\LenToUnit{\AA@x},12){#1}}
   \renewcommand{\authorcrfont}{\scriptsize}
   \setlength{\AA@width}{\textwidth}

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -212,7 +212,7 @@
     \fi%
     \authorcrfont\parbox[b]{\AA@width-1.4cm}{
       \ifAA@LNCS%
-        \AA@publication, pp. \thepage--\pageref{LastPage}, \AA@year.\\%
+        \AA@publication, pp. \thepage--\pageref{LastPage}, \AA@year.
         \ifAA@nocopyright\relax\else
           \textcopyright~\AA@year~\AA@publisher.
         \fi

--- a/brucker-authorarchive-2016-acm.tex
+++ b/brucker-authorarchive-2016-acm.tex
@@ -1,0 +1,43 @@
+\documentclass[sigconf]{acmart}
+\copyrightyear{2017}
+\acmYear{2017}
+\setcopyright{acmlicensed}
+\acmConference[LHack '16]{1st International Conference on \LaTeX-Hacks}{December 4--6, 2017}{Salzburg, Austria}
+\acmBooktitle{LHack '16: The 1st International Conference on \LaTeX-Hacks, December 4--6, 2017, Salzburg, Austria}
+\acmPrice{15.00}
+\acmDOI{10.1145/000000.000000}
+\acmISBN{000-0-0000-0000-0/00/00}
+
+\usepackage[ACM,
+   key=brucker-authorarchive-2016,
+   year=2016,
+   publication={Anonymous et al. (eds). Proceedings of the International
+       Conference on LaTeX-Hacks, ACM, 2016},
+   startpage={42},
+   doi={00/0000},
+   nocopyright
+ ]{authorarchive}
+
+\usepackage{lipsum}
+
+\title{A Simple Example of the \texttt{authorarchive} Package for \LaTeX}
+\author{\protect\href{http://www.brucker.ch/}{Achim D. Brucker}}
+%\institute{Some Departement, Somewhere}
+
+\begin{document}
+  \maketitle{}
+
+  \begin{abstract}
+  \lipsum[1-2]
+  \end{abstract}
+
+  \section{Introduction}
+  \lipsum[1-4]
+
+  \section{Contribution}
+  \lipsum[5-10]
+
+  \section{Conclusion}
+  \lipsum[10-12]
+\end{document}
+


### PR DESCRIPTION
### Added
- The links to the embedded files (references) are typeset at the bottom of the paper.

### Changed
- Updated LNCS output to the requirements of [Springer's Consent to Publish v3](http://resource-cms.springer.com/springer-cms/rest/v1/content/731196/data/v3).
- If `nourl` is active, the DOI is used as link for the QR code.
- Text is centered if no QR code (`nourl` + no DOI) is generated.
- File embedding is implemented using the [attachfilfe](https://ctan.org/pkg/attachfile) package.
- ACM format adapted to [acmart](https://github.com/borisveytsman/acmart) v1.50.
