### PR TITLE
Prevent too large space after "al."

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ A simple use for LNCS-formatted papers is as follows:
 \usepackage[LNCS,
    key=brucker-authorarchive-2016,
    year=2016,
-   publication={Anonymous et al. (eds). Proceedings of the International
-       Conference on LaTeX-Hacks, LNCS~42. Some Publisher, 2016.}
+   publication={Anonymous et al.\ (eds). Proceedings of the International
+       Conference on LaTeX-Hacks, LNCS~42. Some Publisher, 2016}
    startpage={42},
    doi={00/00_00},
    doiText={0/00\_00},

--- a/examples/brucker-authorarchive-2016-IEEEtran.tex
+++ b/examples/brucker-authorarchive-2016-IEEEtran.tex
@@ -3,7 +3,7 @@
 \usepackage[IEEE,
    key=brucker-authorarchive-2016,
    year=2016,
-   publication={Anonymous et al. (eds). Proceedings of the International
+   publication={Anonymous et al.\ (eds). Proceedings of the International
        Conference on LaTeX-Hacks. Some Publisher, 2016},
    startpage={42},
    doi={00/00_00},

--- a/examples/brucker-authorarchive-2016-article.tex
+++ b/examples/brucker-authorarchive-2016-article.tex
@@ -3,7 +3,7 @@
 \usepackage[
    key=brucker-authorarchive-2016,
    year=2016,
-   publication={Anonymous et al. (eds). Proceedings of the International
+   publication={Anonymous et al.\ (eds). Proceedings of the International
        Workshop on LaTeX-Hacks, 2016},
    startpage={42},
    doi={00/0000},

--- a/examples/brucker-authorarchive-2016-entcs.tex
+++ b/examples/brucker-authorarchive-2016-entcs.tex
@@ -3,7 +3,7 @@
 \usepackage[ENTCS,
    key=brucker-authorarchive-2016,
    year=2016,
-   publication={Anonymous et al. (eds). Proceedings of the International
+   publication={Anonymous et al.\ (eds). Proceedings of the International
        Conference on LaTeX-Hacks, Some Publisher, 2016},
    startpage={42},
    doi={00/00_00},

--- a/examples/brucker-authorarchive-2016-llncs.tex
+++ b/examples/brucker-authorarchive-2016-llncs.tex
@@ -3,7 +3,7 @@
 \usepackage[LNCS,
    key=brucker-authorarchive-2016,
    year=2016,
-   publication={Anonymous et al. (eds). Proceedings of the International
+   publication={Anonymous et al.\ (eds). Proceedings of the International
        Conference on LaTeX-Hacks, LNCS~42. Some Publisher, 2016},
    startpage={42},
    doi={00/00_00},

--- a/examples/brucker-authorarchive-2016-lni.tex
+++ b/examples/brucker-authorarchive-2016-lni.tex
@@ -3,7 +3,7 @@
 \usepackage[LNI,
    key=brucker-authorarchive-2016,
    year=2016,
-   publication={Anonymous et al. (eds). Proceedings of the International
+   publication={Anonymous et al.\ (eds). Proceedings of the International
        Conference on LaTeX-Hacks. Some Publisher, 2016},
    startpage={42},
    doi={00/00_00},

--- a/examples/brucker-authorarchive-2016-sig-alternate.tex
+++ b/examples/brucker-authorarchive-2016-sig-alternate.tex
@@ -2,7 +2,7 @@
 \usepackage[ACM,
    key=brucker-authorarchive-2016,
    year=2016,
-   publication={Anonymous et al. (eds). Proceedings of the International
+   publication={Anonymous et al.\ (eds). Proceedings of the International
        Conference on LaTeX-Hacks, ACM, 2016},
    startpage={42},
    doi={00/0000},


### PR DESCRIPTION
Typically, `\frenchspacing` is active, which treats dots at end of sentences different than dots in the middle of a sentence.

Long discussion about that thing:
- https://english.stackexchange.com/a/2602/66058
- https://abovethelaw.com/2017/03/in-defense-of-space-the-extra-one-after-a-period/

To prevent a too long space at abbreviations one has to use `\ `. In case of capital letters, this is not necessary, because that is not treated as end-of-sentence. That means "Achim D. Brucker" does not need to be modified.

This refs https://github.com/adbrucker/llncsconf/pull/2
