### PR TITLE
Switch to intopdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated LNCS output to the requirements of [Springer's Consent to Publish v3](http://resource-cms.springer.com/springer-cms/rest/v1/content/731196/data/v3).
 - If `nourl` is active, the DOI is used as link for the QR code.
 - Text is centered if no QR code (`nourl` + no DOI) is generated.
-- File embedding is implemented using the [attachfilfe](https://ctan.org/pkg/attachfile) package.
+- File embedding is implemented using the [intopdf](https://www.ctan.org/pkg/intopdf) package. Links to the embedded files are shown in the generated PDF.
 - ACM format adapted to [acmart](https://github.com/borisveytsman/acmart) v1.50.
 
 ## [1.0.0] - 2018-02-21

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -20,7 +20,7 @@
 \RequirePackage[inline]{enumitem}
 \RequirePackage{graphicx}
 \RequirePackage{eso-pic}
-\RequirePackage{attachfile}
+\RequirePackage{intopdf}
 \RequirePackage{kvoptions}
 \RequirePackage{hyperref}
 \RequirePackage{calc}
@@ -259,59 +259,24 @@
       \ifAA@nobib\relax\else%
         \ifthenelse{\boolean{AA@bibExists}}{%
           \hfill
-          % We need "doubleprint", because the text of \textattachfile
-          % is not printed when printing a PDF
-          % We use the idea from
-          % https://tex.stackexchange.com/a/19045/9075, accepting that
-          % the pointers to the files are renderedin semi-bold way
-          \newlength{\Urlname}
-          \newcommand{\doubleprint}[1]{\setlength{\Urlname}{\widthof{#1}}\hspace{-\Urlname}#1}
           \begin{itemize*}[label={}, itemjoin={,}]
             \IfFileExists{\AA@bibBibTeX}{%
-              \item \textattachfile[%
-                print=true,%
-                color=0 0 0,%
-                icon=Paperclip,%
-                description={BibTeX entry of this paper},%
-                mimetype=application/x-bibtex%
-              ]{\AA@bibBibTeX}{\BibTeX}%
-              \doubleprint{\BibTeX}
+              \item \attachandlink{\AA@bibBibTeX}[application/x-bibtex]{BibTeX entry of this paper}{\BibTeX}%
             }{
               \typeout{No file \AA@bibBibTeX found. Not embedded reference in BibTeX format.}
             }
             \IfFileExists{\AA@bibWord}{%
-              \item \textattachfile[%
-                print=true,%
-                color=0 0 0,%
-                icon=Paperclip,%
-                description={XML entry of this paper (e.g., for Word 2007 and later)},%
-                mimetype=application/xml%
-              ]{\AA@bibWord}{Word}%
-                \doubleprint{Word}%
+              \item \attachandlink{\AA@bibWord}[application/xml]{XML entry of this paper (e.g., for Word 2007 and later)}{Word}%
             }{
               \typeout{No file \AA@bibWord found. Not embedded reference for Word 2007 and later.}
             }
             \IfFileExists{\AA@bibEndnote}{%
-              \item \textattachfile[%
-                print=true,%
-                color=0 0 0,%
-                icon=Paperclip,%
-                description={Endnote entry of this paper},%
-                mimetype=application/x-endnote-refer%
-              ]{\AA@bibEndnote}{EndNote}%
-              \doubleprint{EndNote}%
+              \item \attachandlink{\AA@bibEndnote}[application/x-endnote-refer]{Endnote entry of this paper}{EndNote}%
             }{
               \typeout{No file \AA@bibEndnote found. Not embedded reference in Endnote format.}
             }
             \IfFileExists{\AA@bibRIS}{%
-              \item \textattachfile[%
-                print=true,%
-                color=0 0 0,%
-                icon=Paperclip,%
-                description={RIS entry of this paper},%
-                mimetype=application/x-research-info-systems%
-              ]{\AA@bibRIS}{RIS}%
-              \doubleprint{RIS}%
+              \item \attachandlink{\AA@bibRIS}[application/x-research-info-systems]{RIS entry of this paper}{RIS}%
             }{
               \typeout{No file \AA@bibRIS found. Not embedded reference in RIS format.}
             }


### PR DESCRIPTION
[intopdf](https://www.ctan.org/pkg/intopdf) is a new package with better embedding of files into the PDF. - See https://tex.stackexchange.com/a/418827/9075 for a long discussion.

Even though TeXlive 2017 is frozen now, `intopdf` won't make it into current latex build environments, the current development version of authorarchive is also not part of TeXlive 2017, so there is no need for a fallback to `attachfile` and it can just be replaced by intopdf.