### PR TITLE
Add SPDX identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ converting between these different formats for bibliographic
 references easily. 
 
 ## Notes on Self-Archiving
-
 Before using this package, please check with your signed copyright form,
 which rights you have. None of the authors might be hold liable for copyright
 violations by using this package.
@@ -115,7 +114,7 @@ Thus, the proposed configuration for Springer is as follows:
 \usepackage[LNCS,
    key=brucker-authorarchive-2016,
    year=2016,
-   publication={Anonymous et al. (eds). Proceedings of the International
+   publication={Anonymous et al.\ (eds). Proceedings of the International
        Conference on LaTeX-Hacks, LNCS~42. Springer, 2016.}
    startpage={42},
    doi={10.1038/authorarchive},
@@ -131,7 +130,7 @@ prints the note centered at the bottom of the first page.
 \usepackage[
    key=brucker-authorarchive-2017,
    year=2017,
-   publication={Anonymous et al. (eds). Proceedings of the International
+   publication={Anonymous et al.\ (eds). Proceedings of the International
        Conference on LaTeX-Hacks, CEUR-WS Vol~42, 2017.}
    startpage={42},
    doi={10.1039/authorarchive},
@@ -169,3 +168,5 @@ Main author: [Achim D. Brucker](http://www.brucker.ch/)
 If not otherwise stated, all sub-projects are dual-licensed under a
 2-clause BSD-style license and/or the LPPL version 1.3c or (at your 
 opinion) any later version.
+
+SPDX-License-Identifier: LPPL-1.3c+ OR BSD-2-Clause


### PR DESCRIPTION
This adds the SPDX identifier also in README.md. Refs 664e0a518f36abb51dd757cd8f7189bbe97b1df3.

This also enforces a inter-word space. Refs https://github.com/adbrucker/authorarchive/pull/5 (especially https://github.com/adbrucker/authorarchive/pull/5/commits/e6c71db4b0ea6febdfa4111425e015e55743cc43).

Although the README.md does not follow the rule "Surround headers by a single empty line except at the beginning of the file." stated by the [markdown style guide](http://www.cirosantilli.com/markdown-style-guide/), I removed the empty line after the only heading with an empty line afterwards.