### PR TITLE
Use lastpage package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Text is centered if no QR code (`nourl` + no DOI) is generated.
 - File embedding is implemented using the [intopdf](https://www.ctan.org/pkg/intopdf) package. Links to the embedded files are shown in the generated PDF.
 - ACM format adapted to [acmart](https://github.com/borisveytsman/acmart) v1.50.
+- Use [lastpage](https://ctan.org/pkg/lastpage) package instead of custom label.
 
 ## [1.0.0] - 2018-02-21
 ### Added

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -181,8 +181,7 @@
   pdftitle      = {\@title},
 }
 
-\AtEndDocument{\label{LastPage}}
-
+\RequirePackage{lastpage}
 
 \newsavebox{\AA@authoratBox}
 


### PR DESCRIPTION
I had issues with following (rather) minimal example, that `LastPage` could not be found. The solution was to replace the custom label by the [lastpage](https://ctan.org/pkg/lastpage) package. Works great.

Think, it solves the edge case if the paper consists of a single page only. (Which it does not in this case, I have the `includepdf` command wrong (right `\includepdf[pages=-]{paper.pdf}`). Nevertheless, others could face this issue in a real-world setting)

```
\documentclass{scrartcl}
\usepackage{pax}
\usepackage{pdfpages}
\usepackage{xmpincl}
\includexmp{\jobname}

\usepackage[LNCS,
   key=KoppAZ-MADR-ZEUS-2018,
   year=2018,
   publication={Herzberg et al.\ (eds). Proceedings of the 10th ZEUS Workshop, Vol-2027, CEUR-WS-org, 2018},
   startpage={55},
   nocopyright,
   nourl
 ]{authorarchive}

\begin{document}
\thispagestyle{empty}
\pagestyle{empty}
\includepdf{paper.pdf}
\end{document}
```