### PR TITLE
Support a4paper in the case of LNCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - The links to the embedded files (references) are typeset at the bottom of the paper.
+- Support for `a4paper` for LNCS papers.
 
 ### Changed
 - Updated LNCS output to the requirements of [Springer's Consent to Publish v3](http://resource-cms.springer.com/springer-cms/rest/v1/content/731196/data/v3).

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -137,9 +137,14 @@
 %%%% LNCS
 \ifAA@LNCS%
   \setkeys{AA}{publisher=Springer-Verlag}
-  \renewcommand{\authorat}[1]{\put(\LenToUnit{\AA@x},23){#1}}
   \renewcommand{\authorcrfont}{\scriptsize}
-  \pdfpagesattr{/CropBox [92 65 523 731]}% LNCS page: 152x235 mm
+  \@ifclasswith{llncs}{a4paper}{%
+    \pdfpagesattr{/CropBox [92 114 523 780]}%
+    \renewcommand{\authorat}[1]{\put(\LenToUnit{\AA@x},40){#1}}%
+  }{%
+    \pdfpagesattr{/CropBox [92 65 523 731]}% LNCS page: 152x235 mm
+    \renewcommand{\authorat}[1]{\put(\LenToUnit{\AA@x},23){#1}}
+  }
   \setlength{\AA@width}{\textwidth}
   \setcounter{tocdepth}{2}
 \fi

--- a/examples/brucker-authorarchive-2016-llncs-a4.tex
+++ b/examples/brucker-authorarchive-2016-llncs-a4.tex
@@ -1,0 +1,20 @@
+\documentclass[final, runningheads, USenglish, a4paper, pdftex]{llncs}
+\usepackage[T1]{fontenc}
+\usepackage[LNCS,
+   key=brucker-authorarchive-2016,
+   year=2016,
+   publication={Anonymous et al.\ (eds). Proceedings of the International
+       Conference on LaTeX-Hacks, LNCS~42. Some Publisher, 2016},
+   startpage={42},
+   doi={00/00_00},
+   doiText={0/00\_00},
+   nocopyright
+ ]{../authorarchive}
+
+\usepackage{lipsum}
+
+\title{A Simple Example of the \texttt{authorarchive} Package for \LaTeX}
+\author{\protect\href{http://www.brucker.ch/}{Achim D. Brucker}}
+\institute{Some Departement, Somewhere}
+
+\input{input/body}


### PR DESCRIPTION
Context: LNCS allows the `a4paper` option, which is also used when producing proceedings. In this case, authorarchive provides the wrong cropping. This patch resolves the issue by providing the `LNCSAF` (for LNCS A4) option.

Before the patch:

![grafik](https://user-images.githubusercontent.com/1366654/38720682-7b98739e-3ef7-11e8-8ce7-5cdeb9f57bd9.png)

After the patch:

![grafik](https://user-images.githubusercontent.com/1366654/38720635-4d144e12-3ef7-11e8-98fd-fd39fd563734.png)
