### PR TITLE
Text uses full width if no QR code is generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Updated LNCS output to the requirements of [Springer's Consent to Publish v3](http://resource-cms.springer.com/springer-cms/rest/v1/content/731196/data/v3).
 - If `nourl` is active, the DOI is used as link for the QR code.
-- Text is centered if no QR code (`nourl` + no DOI) is generated.
 - File embedding is implemented using the [intopdf](https://www.ctan.org/pkg/intopdf) package. Links to the embedded files are shown in the generated PDF.
 - ACM format adapted to [acmart](https://github.com/borisveytsman/acmart) v1.50.
 - Use [lastpage](https://ctan.org/pkg/lastpage) package instead of custom label.

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -224,8 +224,7 @@
       \bgroup%
         \normallineskiplimit=0pt%
         \ifAA@nourl%
-           \ifx\AA@doi\@empty%
-             \hspace{0.585cm}
+           \ifx\AA@doi\@empty\relax%
            \else%
               \qrcode[hyperlink,height=1.17cm,padding]{https://doi.org/\AA@doi}%
             \fi%
@@ -234,6 +233,7 @@
         \fi%
       \egroup%
     }%
+    \ifAA@nourl\ifx\AA@doi\@empty\addtolength{\AA@width}{1.4cm}\fi\fi
     \parbox{\AA@width-1.4cm}{\authorcrfont%
       \ifAA@LNCS%
         \AA@publication, \AA@pageinfo  \AA@year. %

--- a/examples/brucker-authorarchive-2016-IEEEtran-nourl.tex
+++ b/examples/brucker-authorarchive-2016-IEEEtran-nourl.tex
@@ -1,0 +1,22 @@
+\documentclass[conference]{IEEEtran}
+\usepackage[T1]{fontenc}
+\usepackage[IEEE,
+   key=brucker-authorarchive-2016,
+   year=2016,
+   publication={Anonymous et al.\ (eds). Proceedings of the International
+       Conference on LaTeX-Hacks. Some Publisher},
+   startpage={42},
+   nourl,
+   nocopyright
+ ]{../authorarchive}
+
+\usepackage{lipsum}
+
+\title{A Simple Example of the \texttt{authorarchive} Package for \LaTeX}
+\author{%
+    \IEEEauthorblockN{\protect\href{http://www.brucker.ch/}{Achim D. Brucker}}
+    \IEEEauthorblockA{Some Departement \\ Somewhere}
+}
+
+\input{input/body}
+


### PR DESCRIPTION
Before

![grafik](https://user-images.githubusercontent.com/1366654/57988363-b0669100-7a8d-11e9-9473-e31bcdcc52c9.png)

After:

![grafik](https://user-images.githubusercontent.com/1366654/57988354-8319e300-7a8d-11e9-9ef3-aa070a34d694.png)
