### PR TITLE
Add ORCID icon to example brucker-authorarchive-2016-llncs.tex

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
 ## Installation
 
 Copy `authorarchive.sty` and the directory `icons` in a directory that
-is searched by LaTeX (e.g,. either your `texmf` tree or the local
-directory with your main LaTeX file.
+is searched by LaTeX (e.g., either your `texmf` tree or the local
+directory with your main LaTeX file).
 
 ## Usage
 

--- a/examples/brucker-authorarchive-2016-llncs.tex
+++ b/examples/brucker-authorarchive-2016-llncs.tex
@@ -1,5 +1,11 @@
 \documentclass[final, runningheads, USenglish, pdftex]{llncs}
 \usepackage[T1]{fontenc}
+
+% Quickly make vector_iD_icon.pdf available to authorarchive.
+% The global installation is described in ../README.md
+\usepackage{graphicx}
+\graphicspath{{../icons/}}
+
 \usepackage[LNCS,
    key=brucker-authorarchive-2016,
    year=2016,
@@ -8,13 +14,14 @@
    startpage={42},
    doi={00/00_00},
    doiText={0/00\_00},
+   orcidicon,
    nocopyright
  ]{../authorarchive}
 
 \usepackage{lipsum}
 
 \title{A Simple Example of the \texttt{authorarchive} Package for \LaTeX}
-\author{\protect\href{http://www.brucker.ch/}{Achim D. Brucker}}
+\author{\protect\href{http://www.brucker.ch/}{Achim D. Brucker}\orcidID{0000-0002-6355-1200}}
 \institute{Some Departement, Somewhere}
 
 \input{input/body}

--- a/icons/README.md
+++ b/icons/README.md
@@ -1,8 +1,8 @@
 # Icons for the use with authorarchive
 
-This directory contains icons that might be used together with 
-the authorarchive LaTeX style. The use of these icons is 
-restricted by the respective copyright holders. 
+This directory contains icons that might be used together with
+the authorarchive LaTeX style. The use of these icons is
+restricted by the respective copyright holders.
 
 ## ORCID iD Icon
 


### PR DESCRIPTION
The example missed the ORCID feature.