### PR TITLE
Remove obsolete heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
     - [Key/Value Options](#key-value-options)
   - [Embedding Bibliography Entries](#embedding-bibliography-entries)
   - [Notes on Self-Archiving](#notes-on-self-archiving)
-    - [LNCS](#lncs)
   - [Usage at arXiv.org](#usage-at-arxivorg)
   - [Other publishers](#other-publishers)
   - [Alternative Packages](#alternative-packages)
@@ -118,8 +117,6 @@ or the postprint. For more information on that, read on at
 
 None of the authors might be hold liable for copyright
 violations by using this package.
-
-### LNCS
 
 ## Usage at arXiv.org
 


### PR DESCRIPTION
In https://github.com/adbrucker/authorarchive/commit/8ed9abc1a79541a7ce5cf71906d6d156ad9bbf4d#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5, information on LNCS/springer was removed, but not the heading.