### PR TITLE
Fix filename

### DIFF
--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -310,7 +310,7 @@
           \hfill
           \begin{itemize*}[label={}, itemjoin={,}]
             \IfFileExists{\AA@bibBibTeX}{%
-              \item \attachandlink{\AA@bibBibTeX}[application/x-bibtex]{BibTeX entry of this paper}{\BibTeX}%
+              \item \attachandlink[\AA@key.bib]{\AA@bibBibTeX}[application/x-bibtex]{BibTeX entry of this paper}{\BibTeX}%
             }{%
               \IfFileExists{\AA@bibBibTeXLong}{%
                 \item \attachandlink[\AA@key.bib]{\AA@bibBibTeXLong}[application/x-bibtex]{BibTeX entry of this paper}{\BibTeX}%
@@ -319,17 +319,17 @@
               }%
             }%
             \IfFileExists{\AA@bibWord}{%
-              \item \attachandlink{\AA@bibWord}[application/xml]{XML entry of this paper (e.g., for Word 2007 and later)}{Word}%
+              \item \attachandlink[\AA@key.word.xml]{\AA@bibWord}[application/xml]{XML entry of this paper (e.g., for Word 2007 and later)}{Word}%
             }{%
               \typeout{No file \AA@bibWord{} found. Not embedded reference for Word 2007 and later.}%
             }%
             \IfFileExists{\AA@bibEndnote}{%
-              \item \attachandlink{\AA@bibEndnote}[application/x-endnote-refer]{Endnote entry of this paper}{EndNote}%
+              \item \attachandlink[\AA@key.enw]{\AA@bibEndnote}[application/x-endnote-refer]{Endnote entry of this paper}{EndNote}%
             }{%
               \typeout{No file \AA@bibEndnote{} found. Not embedded reference in Endnote format.}%
             }%
             \IfFileExists{\AA@bibRIS}{%
-              \item \attachandlink{\AA@bibRIS}[application/x-research-info-systems]{RIS entry of this paper}{RIS}%
+              \item \attachandlink[\AA@key.ris]{\AA@bibRIS}[application/x-research-info-systems]{RIS entry of this paper}{RIS}%
             }{%
               \typeout{No file \AA@bibRIS{} found. Not embedded reference in RIS format.}%
             }%

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -310,26 +310,26 @@
           \hfill
           \begin{itemize*}[label={}, itemjoin={,}]
             \IfFileExists{\AA@bibBibTeX}{%
-              \item \attachandlink[\AA@key.bib]{\AA@bibBibTeX}[application/x-bibtex]{BibTeX entry of this paper}{\BibTeX}%
+              \item \expanded{\attachandlink[\AA@key.bib]{\AA@bibBibTeX}[application/x-bibtex]{BibTeX entry of this paper}{\BibTeX}}%
             }{%
               \IfFileExists{\AA@bibBibTeXLong}{%
-                \item \attachandlink[\AA@key.bib]{\AA@bibBibTeXLong}[application/x-bibtex]{BibTeX entry of this paper}{\BibTeX}%
+                \item \expanded{\attachandlink[\AA@key.bib]{\AA@bibBibTeXLong}[application/x-bibtex]{BibTeX entry of this paper}{\BibTeX}}%
               }{%
                 \typeout{No file \AA@bibBibTeX{} (and no \AA@bibBibTeXLong) found. Not embedded reference in BibTeX format.}%
               }%
             }%
             \IfFileExists{\AA@bibWord}{%
-              \item \attachandlink[\AA@key.word.xml]{\AA@bibWord}[application/xml]{XML entry of this paper (e.g., for Word 2007 and later)}{Word}%
+              \item \expanded{\attachandlink[\AA@key.word.xml]{\AA@bibWord}[application/xml]{XML entry of this paper (e.g., for Word 2007 and later)}{Word}}%
             }{%
               \typeout{No file \AA@bibWord{} found. Not embedded reference for Word 2007 and later.}%
             }%
             \IfFileExists{\AA@bibEndnote}{%
-              \item \attachandlink[\AA@key.enw]{\AA@bibEndnote}[application/x-endnote-refer]{Endnote entry of this paper}{EndNote}%
+              \item \expanded{\attachandlink[\AA@key.enw]{\AA@bibEndnote}[application/x-endnote-refer]{Endnote entry of this paper}{EndNote}}%
             }{%
               \typeout{No file \AA@bibEndnote{} found. Not embedded reference in Endnote format.}%
             }%
             \IfFileExists{\AA@bibRIS}{%
-              \item \attachandlink[\AA@key.ris]{\AA@bibRIS}[application/x-research-info-systems]{RIS entry of this paper}{RIS}%
+              \item \expanded{\attachandlink[\AA@key.ris]{\AA@bibRIS}[application/x-research-info-systems]{RIS entry of this paper}{RIS}}%
             }{%
               \typeout{No file \AA@bibRIS{} found. Not embedded reference in RIS format.}%
             }%

--- a/examples/brucker-authorarchive-2016-IEEEtran-nourl.tex
+++ b/examples/brucker-authorarchive-2016-IEEEtran-nourl.tex
@@ -17,7 +17,7 @@
 \title{A Simple Example of the \texttt{authorarchive} Package for \LaTeX}
 \author{%
     \IEEEauthorblockN{\protect\href{http://www.brucker.ch/}{Achim D. Brucker}}
-    \IEEEauthorblockA{Some Departement \\ Somewhere}
+    \IEEEauthorblockA{Some Department \\ Somewhere}
 }
 
 

--- a/examples/brucker-authorarchive-2016-IEEEtran.tex
+++ b/examples/brucker-authorarchive-2016-IEEEtran.tex
@@ -18,7 +18,7 @@
 \title{A Simple Example of the \texttt{authorarchive} Package for \LaTeX}
 \author{%
     \IEEEauthorblockN{\protect\href{http://www.brucker.ch/}{Achim D. Brucker}}
-    \IEEEauthorblockA{Some Departement \\ Somewhere}
+    \IEEEauthorblockA{Some Department \\ Somewhere}
 }
 
 

--- a/examples/brucker-authorarchive-2016-llncs-a4.tex
+++ b/examples/brucker-authorarchive-2016-llncs-a4.tex
@@ -17,7 +17,7 @@
 
 \title{A Simple Example of the \texttt{authorarchive} Package for \LaTeX}
 \author{\protect\href{http://www.brucker.ch/}{Achim D. Brucker}}
-\institute{Some Departement, Somewhere}
+\institute{Some Department, Somewhere}
 
 \begin{document}
   \maketitle{}

--- a/examples/brucker-authorarchive-2016-llncs.tex
+++ b/examples/brucker-authorarchive-2016-llncs.tex
@@ -23,7 +23,7 @@
 
 \title{A Simple Example of the \texttt{authorarchive} Package for \LaTeX}
 \author{\protect\href{http://www.brucker.ch/}{Achim D. Brucker}\orcidID{0000-0002-6355-1200}}
-\institute{Some Departement, Somewhere}
+\institute{Some Department, Somewhere}
 
 \begin{document}
   \maketitle{}

--- a/examples/brucker-authorarchive-2016-lni.tex
+++ b/examples/brucker-authorarchive-2016-lni.tex
@@ -19,7 +19,7 @@
 \title{A Simple Example of the \texttt{authorarchive} Package for \LaTeX}
 \author{%
     \protect\href{http://www.brucker.ch/}{Achim D. Brucker}\\
-    Some Departement\\ 
+    Some Department\\
     Somewhere
 }
 


### PR DESCRIPTION
When providing a full local path to the embeeded files, only the filename should (IMHO) be written into the PDF.

This PR fixes this.

The filename still is not shown in Acrobat Reader, because of https://github.com/zauguin/intopdf/issues/4.

Minor additonal thing: I fixed typos in the example files.