### PR TITLE
Fix links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Initial version uploaded to CTAN.
+
 [Unreleased]: https://git.logicalhacking.com/adbrucker/authorarchive/compare/v1.3.0...HEAD
 [1.3.0]: https://git.logicalhacking.com/adbrucker/authorarchive/compare/v1.3.0...v1.3.0
 [1.2.1]: https://git.logicalhacking.com/adbrucker/authorarchive/compare/v1.2.0...v1.2.1


### PR DESCRIPTION
The links got lost because the links were placed directly after a list - not separated by an empty line.

Before:

![image](https://user-images.githubusercontent.com/1366654/234783321-badb83b1-9292-4a10-8bda-7fc22b3983a0.png)

After:

![image](https://user-images.githubusercontent.com/1366654/234783440-af747c2b-e53c-4c9c-8659-fb455fd05f5d.png)
