### PR TITLE
Fix \BibTeX definition

### DIFF
--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -26,7 +26,9 @@
 \RequirePackage{calc}
 \RequirePackage{qrcode}
 \RequirePackage{etoolbox}
-\newrobustcmd\BibTeX{Bib\TeX}
+\providerobustcmd{\BibTeX}{{%
+    \normalfont B\kern-0.5em{\scshape i\kern-0.25em b}\kern-0.8em\TeX%
+}}
 %
 %Better url breaking
 \g@addto@macro{\UrlBreaks}{\UrlOrds}


### PR DESCRIPTION
According to https://github.com/borisveytsman/acmart/issues/335, `\BibTeX` is defined differently.

I stumbled upon it, because my `.tex` file had `\BibTeX` defined. Therefore, I changed `newrobustcmd` into `providerobustcmd`, too. Maybe, it should be wrapped in `\AtBeginDocument{%`, too?