### PR TITLE
Fix setting publisher at \authorsetup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+### Fixed
+
+- `startpage` and publisher information correctly handled at `\authorsetup{}`
+
 ## [1.3.0] - 2023-02-10
 
 ### Changed

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -141,7 +141,7 @@
 }
 
 
-
+\AtBeginDocument{
 %%%% sig-alternate.cls
 \ifAA@ACM%
   \ifthenelse{\equal{\AA@publisher}{UNKNOWN PUBLISHER}}{%
@@ -220,7 +220,7 @@
   \setlength{\AA@width}{\textwidth}
   \setcounter{tocdepth}{2}
 \fi
-%
+}
 
 \hypersetup{%
   draft         = false,

--- a/authorarchive.sty
+++ b/authorarchive.sty
@@ -134,14 +134,14 @@
 \setlength{\AA@width}{\textwidth}
 
 \def\AA@pageinfo{}
+
+\AtBeginDocument{
 \ifthenelse{\equal{\AA@startpage}{UNKNOWN START PAGE}}{%
 }{%
   \setcounter{page}{\AA@startpage}%
   \def\AA@pageinfo{pp. \thepage--\pageref{\aa@lastpage}, }
 }
 
-
-\AtBeginDocument{
 %%%% sig-alternate.cls
 \ifAA@ACM%
   \ifthenelse{\equal{\AA@publisher}{UNKNOWN PUBLISHER}}{%


### PR DESCRIPTION
When following the "simple use" of README.md, one uses `\authorsetup`. That has the drawback that publisher configurations were not applied. The reason is that the `\ifAA@ACM` (and other) checks are executed when loading the the class - and not after execution of `\authorsetup`.

Which this patch, these commands are executed at `\begin{document}`.

Before the patch:

![image](https://github.com/adbrucker/authorarchive/assets/1366654/395e65d0-7124-48c7-8a37-aa929248a33b)

After the patch:

![image](https://github.com/adbrucker/authorarchive/assets/1366654/b59d596e-3db4-4efa-8ff3-8fc068969dc0)

(I removed `nocopyright` in `brucker-authorarchive-2016-IEEEtran`)